### PR TITLE
pipコマンド用の拡張

### DIFF
--- a/kit-proxy.sh
+++ b/kit-proxy.sh
@@ -16,6 +16,8 @@ function enable_proxy() {
     # yarn settings
     yarn config set proxy "${KIT_PROXY}"
     yarn config set https-proxy "${KIT_PROXY}"
+    # pip settings
+    pip config set global.proxy "${KIT_PROXY}"
     echo "Set proxy"
 }
 
@@ -31,6 +33,8 @@ function disable_proxy() {
     # yarn settings
     yarn config delete proxy
     yarn config delete https-proxy
+    # pip settings
+    pip config unset global.proxy
     echo "Unset proxy"
 }
 
@@ -42,6 +46,7 @@ function show_status() {
     echo "NPM HTTPS Proxy: $(npm -g config get https-proxy)"
     echo "Yarn Proxy: $(yarn config get proxy)"
     echo "Yarn HTTPS Proxy: $(yarn config get https-proxy)"
+    echo "Python PIP Proxy: $(pip config get global.proxy 2>/dev/null 1>/dev/null && echo \"active\" || echo \"inactive\")"
 }
 
 function show_help() {


### PR DESCRIPTION
- したこと
    - [enable_proxy()](https://github.com/yoshiyuki-140/kit-proxy/blob/kuro_dev/kit-proxy.sh#L7)にpipのproxy設定を追加した.
    - [disable_proxy()](https://github.com/yoshiyuki-140/kit-proxy/blob/kuro_dev/kit-proxy.sh#L24)にpipのproxy設定をunsetする処理を追加した.
    - [show_status()](https://github.com/yoshiyuki-140/kit-proxy/blob/kuro_dev/kit-proxy.sh#L41C10-L41C23)にpipのstatusをproxyがactiveなら"active"をinableなら"inable"と表示するスクリプトを追加した.

- しなかったこと
    - なし.

- 不安なこと
    - show_status()にてechoでの出力形式がこれで良いのか不安.
